### PR TITLE
レスポンスのアサーションを変更

### DIFF
--- a/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
@@ -5,6 +5,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 import nablarch.core.exception.IllegalConfigurationException;
 import nablarch.core.repository.SystemRepository;
+import nablarch.core.util.StringUtil;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpResponse;
 import nablarch.fw.web.RestMockHttpRequest;
@@ -31,6 +32,7 @@ import java.net.URL;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -56,8 +58,9 @@ public class RestTestSupportTest {
         public void testNormal() {
             HttpResponse response = sendRequest(get("/test"));
             assertStatusCode("200 OK", HttpResponse.Status.OK, response);
-            String sessionIdReplacedResponse = response.toString().replaceAll("JSESSIONID=.+;", "JSESSIONID=DUMMY;");
-            assertThat(readTextResource("response.txt"), is(sessionIdReplacedResponse));
+            assertThat(response.getContentLength(), is("0"));
+            assertThat(response.getContentType(), is("text/plain; charset=utf-8"));
+            assertTrue(StringUtil.isNullOrEmpty(response.getBodyString()));
         }
 
         /**

--- a/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
@@ -281,6 +281,13 @@ public class RestTestSupportTest {
             fail("ここに到達したらExceptionが発生していない");
         }
 
+        @Test
+        public void testReadTextResource() {
+            RestTestSupport sut = new RestTestSupport();
+            setDummyDescription(RestTestSupportTest.class, sut);
+            assertThat(sut.readTextResource("response.txt"), is("HTTP/1.1 200 OK"));
+        }
+
         /**
          * staticなHttpServerを初期化する。
          */

--- a/src/test/resources/nablarch/test/core/http/RestTestSupportTest/response.txt
+++ b/src/test/resources/nablarch/test/core/http/RestTestSupportTest/response.txt
@@ -1,6 +1,1 @@
 HTTP/1.1 200 OK
-Set-Cookie: JSESSIONID=DUMMY;Path=/
-Expires: Thu, 01-Jan-1970 00:00:00 GMT
-Content-Length: 0
-Content-Type: text/plain; charset=utf-8
-


### PR DESCRIPTION
CIとローカルでレスポンスヘッダーの並び順が異なっていたためテキスト比較ではなく、各ヘッダーを比較するように修正しました。