### PR TITLE
ボディが空の場合にContentTypeが未設定になる仕様変更に伴うテスト修正

### DIFF
--- a/src/test/java/nablarch/test/core/http/SimpleRestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/SimpleRestTestSupportTest.java
@@ -56,7 +56,7 @@ public class SimpleRestTestSupportTest {
             HttpResponse response = sendRequest(get("/test"));
             assertStatusCode("200 OK", HttpResponse.Status.OK, response);
             assertThat(response.getContentLength(), is("0"));
-            assertTrue(response.getContentType().startsWith("text/plain"));
+            assertNull(response.getContentType());
             assertThat(response.getCharset(), is(Charset.forName("UTF-8")));
             assertTrue(StringUtil.isNullOrEmpty(response.getBodyString()));
         }


### PR DESCRIPTION
## 背景

https://github.com/nablarch/nablarch-fw-web/pull/92 の修正に伴いレスポンスボディが空の場合には、ContentTypeが未設定になるようになった。

## やったこと
- テストコードの期待値の修正

## 補足
- テストコードの修正のみなので本変更はリリース不要。