### PR TITLE
PATCHメソッドに対応あわせて任意のHTTPのメソッドでリクエストを構築できるように対応

### DIFF
--- a/src/main/java/nablarch/fw/web/RestMockHttpRequestBuilder.java
+++ b/src/main/java/nablarch/fw/web/RestMockHttpRequestBuilder.java
@@ -23,7 +23,7 @@ public class RestMockHttpRequestBuilder {
      * @param uri        URI
      * @return 生成された{@link RestMockHttpRequest}
      */
-    private RestMockHttpRequest newRequest(String httpMethod, String uri) {
+    public RestMockHttpRequest newRequest(String httpMethod, String uri) {
         return new RestMockHttpRequest(bodyConverters, defaultContentType).setMethod(httpMethod)
                 .setRequestUri(uri);
     }
@@ -66,6 +66,16 @@ public class RestMockHttpRequestBuilder {
      */
     public RestMockHttpRequest delete(String uri) {
         return newRequest("DELETE", uri);
+    }
+
+    /**
+     * PATCHのHTTPメソッドで{@link RestMockHttpRequest}を生成する。
+     *
+     * @param uri リクエストURI
+     * @return 生成された{@link RestMockHttpRequest}
+     */
+    public RestMockHttpRequest patch(String uri) {
+        return newRequest("PATCH", uri);
     }
 
     /**

--- a/src/main/java/nablarch/test/core/http/SimpleRestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/SimpleRestTestSupport.java
@@ -117,6 +117,17 @@ public class SimpleRestTestSupport extends TestEventDispatcher {
     }
 
     /**
+     * 任意のHTTPメソッドで{@link RestMockHttpRequest}を生成する。
+     *
+     * @param httpMethod HTTPメソッド
+     * @param uri リクエストURI
+     * @return 生成された{@link RestMockHttpRequest}
+     */
+    public RestMockHttpRequest newRequest(String httpMethod, String uri) {
+        return getHttpRequestBuilder().newRequest(httpMethod, uri);
+    }
+
+    /**
      * GETのHTTPメソッドで{@link RestMockHttpRequest}を生成する。
      *
      * @param uri リクエストURI
@@ -154,6 +165,16 @@ public class SimpleRestTestSupport extends TestEventDispatcher {
      */
     public RestMockHttpRequest delete(String uri) {
         return getHttpRequestBuilder().delete(uri);
+    }
+
+    /**
+     * PATCHのHTTPメソッドで{@link RestMockHttpRequest}を生成する。
+     *
+     * @param uri リクエストURI
+     * @return 生成された{@link RestMockHttpRequest}
+     */
+    public RestMockHttpRequest patch(String uri) {
+        return getHttpRequestBuilder().patch(uri);
     }
 
     /**

--- a/src/test/java/nablarch/fw/web/RestMockHttpRequestBuilderTest.java
+++ b/src/test/java/nablarch/fw/web/RestMockHttpRequestBuilderTest.java
@@ -86,5 +86,13 @@ public class RestMockHttpRequestBuilderTest {
         RestMockHttpRequest deleteReq = sut.delete("test");
         assertThat(deleteReq.getMethod(), is("DELETE"));
         assertThat(deleteReq.getRequestUri(), is("test"));
+
+        RestMockHttpRequest patchReq = sut.patch("test");
+        assertThat(patchReq.getMethod(), is("PATCH"));
+        assertThat(patchReq.getRequestUri(), is("test"));
+
+        RestMockHttpRequest headReq = sut.newRequest("HEAD", "test");
+        assertThat(headReq.getMethod(), is("HEAD"));
+        assertThat(headReq.getRequestUri(), is("test"));
     }
 }

--- a/src/test/java/nablarch/test/core/http/SimpleRestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/SimpleRestTestSupportTest.java
@@ -141,6 +141,14 @@ public class SimpleRestTestSupportTest {
             RestMockHttpRequest deleteReq = delete("test");
             assertThat(deleteReq.getMethod(), is("DELETE"));
             assertThat(deleteReq.getRequestUri(), is("test"));
+
+            RestMockHttpRequest patchReq = patch("test");
+            assertThat(patchReq.getMethod(), is("PATCH"));
+            assertThat(patchReq.getRequestUri(), is("test"));
+
+            RestMockHttpRequest headReq = newRequest("HEAD", "test");
+            assertThat(headReq.getMethod(), is("HEAD"));
+            assertThat(headReq.getRequestUri(), is("test"));
         }
     }
 


### PR DESCRIPTION
newRequestをprivateにしていた設計当初の経緯はわかりませんでしたが、publicにすることによる致命的な問題はないと判断して可視性をあげました。