### PR TITLE
委譲形式で利用できない点を修正

### DIFF
--- a/src/main/java/nablarch/test/core/http/RestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/RestTestSupport.java
@@ -41,7 +41,31 @@ public class RestTestSupport extends SimpleRestTestSupport {
     private static final String SETUP_TABLE_SHEET = "setUpDb";
 
     /** NTFのDBサポート */
-    private final DbAccessTestSupport dbSupport = new DbAccessTestSupport(getClass());
+    private final DbAccessTestSupport dbSupport;
+
+    /**
+     * デフォルトコンストラクタ。
+     * <p>
+     * このコンストラクタでインスタンスを生成し委譲形式で利用した場合、 {@link #setUpDb()} などの
+     * データベース機能を利用するメソッドは使用できない。<br>
+     * データベース機能を利用する場合は、 {@link #RestTestSupport(Class)} を使用すること。
+     * </p>
+     * <p>
+     * このクラスを継承してテストクラスを作成した場合は、デフォルトコンストラクタで初期化していても
+     * データベース機能を利用できる。
+     * </p>
+     */
+    public RestTestSupport() {
+        dbSupport = new DbAccessTestSupport(getClass());
+    }
+
+    /**
+     * テストクラスを指定してインスタンスを生成する。
+     * @param testClass テストクラス
+     */
+    public RestTestSupport(Class<?> testClass) {
+        dbSupport = new DbAccessTestSupport(testClass);
+    }
 
     /**
      * システムリポジトリから設定を取得しHTTPサーバを起動する。

--- a/src/main/java/nablarch/test/core/http/SimpleRestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/SimpleRestTestSupport.java
@@ -331,8 +331,18 @@ public class SimpleRestTestSupport extends TestEventDispatcher {
      * @return ファイル内容の文字列
      */
     protected String readTextResource(String fileName) {
+        return readTextResource(testDescription.getTestClass(), fileName);
+    }
+
+    /**
+     * 指定したテストクラスと同じパッケージにあるファイルを読み込み文字列を返す。
+     * @param testClass テストクラス
+     * @param fileName 読み込むファイル名
+     * @return ファイル内容の文字列
+     */
+    public String readTextResource(Class<?> testClass, String fileName) {
         try {
-            URL url = getUrl(testDescription.getTestClassSimpleName() + "/" + fileName);
+            URL url = getUrl(testClass, testClass.getSimpleName() + "/" + fileName);
             File file = new File(url.toURI());
             return read(file);
         } catch (URISyntaxException e) {
@@ -347,11 +357,12 @@ public class SimpleRestTestSupport extends TestEventDispatcher {
     /**
      * ファイルのURLを取得する。
      *
+     * @param testClass テストクラス
      * @param fileName 対象のファイル名
      * @return ファイルのURL
      */
-    private URL getUrl(String fileName) {
-        URL url = testDescription.getTestClass().getResource(fileName);
+    private URL getUrl(Class<?> testClass, String fileName) {
+        URL url = testClass.getResource(fileName);
         if (url == null) {
             throw new IllegalArgumentException("couldn't find resource [" + fileName + "].");
         }

--- a/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
@@ -6,6 +6,7 @@ import mockit.Mocked;
 import nablarch.core.exception.IllegalConfigurationException;
 import nablarch.core.repository.SystemRepository;
 import nablarch.test.RepositoryInitializer;
+import nablarch.test.TestSupport;
 import nablarch.test.core.db.DbAccessTestSupport;
 import nablarch.test.core.rule.TestDescription;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
@@ -22,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
 /**
@@ -78,6 +81,36 @@ public class RestTestSupportTest {
     public static class RestTestSupportInstanceTest {
         @Rule
         public ExpectedException expectedException = ExpectedException.none();
+
+        /**
+         * テストクラスを指定するコンストラクタでインスタンスを生成した場合、
+         * DbAccessTestSupport にテストクラスが渡されて初期化されることを確認する。
+         */
+        @Test
+        public void testConstructorWithTestClass() {
+            RestTestSupport sut = new RestTestSupport(RestTestSupportInstanceTest.class);
+
+            DbAccessTestSupport dbSupport = Deencapsulation.getField(sut, "dbSupport");
+            TestSupport testSupport = Deencapsulation.getField(dbSupport, "testSupport");
+            Object testClass = Deencapsulation.getField(testSupport, "testClass");
+
+            assertThat(testClass, is((Object)RestTestSupportInstanceTest.class));
+        }
+
+        /**
+         * デフォルトコンストラクタでインスタンスを生成した場合、
+         * RestTestSupportのクラスオブジェクトが DbAccessTestSupport に渡されて初期化されることを確認する。
+         */
+        @Test
+        public void testDefaultConstructor() {
+            RestTestSupport sut = new RestTestSupport();
+
+            DbAccessTestSupport dbSupport = Deencapsulation.getField(sut, "dbSupport");
+            TestSupport testSupport = Deencapsulation.getField(dbSupport, "testSupport");
+            Object testClass = Deencapsulation.getField(testSupport, "testClass");
+
+            assertThat(testClass, is((Object)RestTestSupport.class));
+        }
 
         /**
          * 拡張子XLS形式のExcelファイルを読み込めることを確認する。
@@ -189,5 +222,4 @@ public class RestTestSupportTest {
             Deencapsulation.setField(sut, "testDescription", description);
         }
     }
-
 }

--- a/src/test/java/nablarch/test/core/http/SimpleRestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/SimpleRestTestSupportTest.java
@@ -118,6 +118,34 @@ public class SimpleRestTestSupportTest {
         }
 
         /**
+         * テストクラスを指定するreadTextResourcesで、
+         * テキストファイルを読み込む際に{@link URISyntaxException}が送出された場合、例外が送出されることを確認する。
+         *
+         * @param url モック化されたURL
+         */
+        @Test
+        public void testReadTextResourceWithTestClass_CatchURISyntaxException(@Mocked final URL url) throws URISyntaxException {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("couldn't read resource [response.txt]. cause [url is invalid: dummy].");
+            new Expectations() {{
+                url.toURI();
+                result = new URISyntaxException("dummy", "url is invalid");
+            }};
+            readTextResource(SimpleRestTestSupportTest.class, "response.txt");
+        }
+
+        /**
+         * テストクラスを指定するreadTextResourcesで、
+         * 存在しないテキストファイルを読み込もうとした場合、例外が送出されることを確認する。
+         */
+        @Test
+        public void testReadTextResourceWithTestClass_NotExistsText() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("couldn't find resource [SimpleRestTestSupportSubClassTest/noFile].");
+            readTextResource(SimpleRestTestSupportSubClassTest.class, "noFile");
+        }
+
+        /**
          * {@link RestMockHttpRequestBuilder#get(String)}
          * {@link RestMockHttpRequestBuilder#post(String)}
          * {@link RestMockHttpRequestBuilder#put(String)}
@@ -204,6 +232,33 @@ public class SimpleRestTestSupportTest {
             SimpleRestTestSupport sut = new SimpleRestTestSupport();
             setDummyDescription(SimpleRestTestSupportTest.class, sut);
             assertThat(sut.readTextResource("response.txt"), is("HTTP/1.1 200 OK"));
+        }
+
+        /**
+         * テストクラスを指定するreadTextResourceで、
+         * テキストファイル読込中に{@link IOException}が送出された場合、{@link IllegalArgumentException}が送出されることを確認する。
+         */
+        @Test
+        public void testReadTextResourceWithTestClass_thrownIOException() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("couldn't read resource [response.txt]. cause [I/O error].");
+            SimpleRestTestSupport sut = new SimpleRestTestSupport() {
+                @Override
+                protected String read(File file) throws IOException {
+                    throw new IOException("I/O error");
+                }
+            };
+            sut.readTextResource(SimpleRestTestSupportTest.class, "response.txt");
+            fail("ここに到達したらExceptionが発生していない");
+        }
+
+        /**
+         * テストクラスを指定するreadTextResourceで、テキストファイルを読み込めることを確認する。
+         */
+        @Test
+        public void testReadTextResourceWithTestClass() {
+            SimpleRestTestSupport sut = new SimpleRestTestSupport();
+            assertThat(sut.readTextResource(SimpleRestTestSupportTest.class, "response.txt"), is("HTTP/1.1 200 OK"));
         }
 
         /**


### PR DESCRIPTION
JUnit5拡張対応の中で、以下2点の問題があり委譲形式で利用できないことが判明。その対応を入れました。

- `SimpleRestTestSupport` の `readTextResource()` が protected のものしかない
- `RestTestSupport` がインスタンスフィールドに持つ `DbAccessTestSupport` に渡すテストクラスが、 `getClass()` 固定になっていて外部から指定できない

1つ目の問題については、 public でテストクラスを追加で指定可能な `readTextResource()` メソッドを追加することで対応。

2つ目の問題については、テストクラスを指定できるコンストラクタを追加することで対応。
