### PR TITLE
単体テスト実装時にリクエストボディー出力の確認を公開メソッドで実施できるようにメソッドを拡張

### DIFF
--- a/src/main/java/nablarch/test/core/http/RestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/RestTestSupport.java
@@ -6,6 +6,7 @@ import nablarch.core.log.LoggerManager;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.FileUtil;
 import nablarch.core.util.annotation.Published;
+import nablarch.fw.web.HttpResponse;
 import nablarch.test.core.db.DbAccessTestSupport;
 import nablarch.test.core.reader.TestDataParser;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -15,6 +16,8 @@ import org.junit.Before;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -340,5 +343,36 @@ public class RestTestSupport extends SimpleRestTestSupport {
             throw new IllegalConfigurationException(createNoComponentMessage(TEST_DATA_PARSER_KEY));
         }
         return parser;
+    }
+
+    /**
+     * HTTPレスポンスボディの内容を表す文字列を返す。
+     *
+     * @return ボディの内容を表す文字列を返す
+     */
+    public String getBodyString(HttpResponse httpResponse)  {
+        try {
+            InputStream inputStream = getBodyStream(httpResponse);
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            byte[] byteSize = new byte[1024];
+            Charset charset = httpResponse.getCharset();
+            
+            int length;
+            while ((length = inputStream.read(byteSize)) != -1) {
+                byteArrayOutputStream.write(byteSize, 0, length);
+            }
+            return byteArrayOutputStream.toString(charset.name());
+        } catch (Exception e) {
+            throw new RuntimeException("response io failed.", e);
+        }
+    }
+
+    /**
+     * HTTPレスポンスボディの内容を保持するストリームを取得する。
+     *
+     * @return HTTPレスポンスボディの内容を保持するストリーム
+     */
+    public InputStream getBodyStream(HttpResponse httpResponse) {
+        return httpResponse.getBodyStream();
     }
 }

--- a/src/main/java/nablarch/test/core/http/RestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/RestTestSupport.java
@@ -358,12 +358,12 @@ public class RestTestSupport extends SimpleRestTestSupport {
             inputStream = getBodyStream(httpResponse);
             byteArrayOutputStream = new ByteArrayOutputStream();
             byte[] buffer = new byte[1024];
-            Charset charset = httpResponse.getCharset();
             
             int length;
             while ((length = inputStream.read(buffer)) != -1) {
                 byteArrayOutputStream.write(buffer, 0, length);
             }
+            Charset charset = httpResponse.getCharset();
             return byteArrayOutputStream.toString(charset.name());
         } catch (Exception e) {
             throw new RuntimeException("response io failed.", e);

--- a/src/main/java/nablarch/test/core/http/RestTestSupport.java
+++ b/src/main/java/nablarch/test/core/http/RestTestSupport.java
@@ -346,24 +346,30 @@ public class RestTestSupport extends SimpleRestTestSupport {
     }
 
     /**
-     * HTTPレスポンスボディの内容を表す文字列を返す。
+     * HTTPレスポンスボディの内容を表す文字列を返す。<br/>
+     * 文字列は{@link HttpResponse#getCharset()}で取得したキャラセットでデコードして取得される。
      *
      * @return ボディの内容を表す文字列を返す
      */
     public String getBodyString(HttpResponse httpResponse)  {
+        InputStream inputStream = null;
+        ByteArrayOutputStream byteArrayOutputStream = null;
         try {
-            InputStream inputStream = getBodyStream(httpResponse);
-            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            byte[] byteSize = new byte[1024];
+            inputStream = getBodyStream(httpResponse);
+            byteArrayOutputStream = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
             Charset charset = httpResponse.getCharset();
             
             int length;
-            while ((length = inputStream.read(byteSize)) != -1) {
-                byteArrayOutputStream.write(byteSize, 0, length);
+            while ((length = inputStream.read(buffer)) != -1) {
+                byteArrayOutputStream.write(buffer, 0, length);
             }
             return byteArrayOutputStream.toString(charset.name());
         } catch (Exception e) {
             throw new RuntimeException("response io failed.", e);
+        } finally {
+            FileUtil.closeQuietly(byteArrayOutputStream);
+            FileUtil.closeQuietly(inputStream);
         }
     }
 

--- a/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
@@ -258,11 +258,6 @@ public class RestTestSupportTest {
             input.read(actualBytes);
 
             assertThat(expectedBytes.length, is(actualBytes.length));
-
-            for(int i = 0; i < expectedBytes.length; i++){
-                if(expectedBytes[i] != actualBytes[i]) fail();
-            }
-
             assertThat(actualBytes, is(expectedBytes));
         }
     }

--- a/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
@@ -231,13 +231,14 @@ public class RestTestSupportTest {
         @Test
         public void testWritingToBodyBuffer() {
             HttpResponse res = new HttpResponse();
+            res.setContentType("text/plain ; charset= \"utf-8\" ");
             assertThat("0", is(res.getContentLength()));
             
-            res.write("Hello world!\n");
+            res.write("Hello world!\nボディテスト\n");
 
             RestTestSupport sut = new RestTestSupport();
             // レスポンスボディ確認
-            assertThat("Hello world!\n", is(sut.getBodyString(res)));
+            assertThat("Hello world!\nボディテスト\n", is(sut.getBodyString(res)));
         }
 
         /**
@@ -246,7 +247,7 @@ public class RestTestSupportTest {
         @Test
         public void testWritingToBodyOutputStream() throws Exception {
             HttpResponse res = new HttpResponse();
-            String expectedString = "Hello world!\n" + "Hello world2!\n" + "Hello world3!\n";
+            String expectedString = "Hello world!\n" + "Hello world2!\n" + "Hello world3!\nボディテスト\n";
             byte[] expectedBytes = expectedString.getBytes(Charset.forName("UTF-8"));
 
             res.write(expectedBytes);

--- a/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/RestTestSupportTest.java
@@ -257,7 +257,6 @@ public class RestTestSupportTest {
             InputStream input = sut.getBodyStream(res);
             input.read(actualBytes);
 
-            assertThat(expectedBytes.length, is(actualBytes.length));
             assertThat(actualBytes, is(expectedBytes));
         }
     }


### PR DESCRIPTION
単体テスト実装時にリクエストボディー出力の確認を公開メソッドで実施できるよう、RestTestSupportにgetBodyString(HttpResponse)とgetBodyStream(HttpResponse)メソッドを拡張