### PR TITLE
NTFでCookie引継ぎ可にする対応で、インスペクションの警告を修正

### DIFF
--- a/src/test/java/nablarch/fw/web/RestMockHttpRequestTest.java
+++ b/src/test/java/nablarch/fw/web/RestMockHttpRequestTest.java
@@ -227,7 +227,6 @@ public class RestMockHttpRequestTest {
         assertThat(sut.toString(), is(POST_JSON_REQUEST));
     }
 
-    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/src/test/java/nablarch/fw/web/RestMockHttpRequestTest.java
+++ b/src/test/java/nablarch/fw/web/RestMockHttpRequestTest.java
@@ -15,8 +15,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -227,6 +227,7 @@ public class RestMockHttpRequestTest {
         assertThat(sut.toString(), is(POST_JSON_REQUEST));
     }
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/src/test/java/nablarch/test/core/http/ComplexRequestResponseProcessorTest.java
+++ b/src/test/java/nablarch/test/core/http/ComplexRequestResponseProcessorTest.java
@@ -12,9 +12,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * {@link ComplexRequestResponseProcessor}のテスト

--- a/src/test/java/nablarch/test/core/http/NablarchSIDManagerTest.java
+++ b/src/test/java/nablarch/test/core/http/NablarchSIDManagerTest.java
@@ -14,11 +14,11 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 /**
  * {@link NablarchSIDManager}のテスト

--- a/src/test/java/nablarch/test/core/http/RequestResponseCookieManagerTest.java
+++ b/src/test/java/nablarch/test/core/http/RequestResponseCookieManagerTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertNull;
  */
 public class RequestResponseCookieManagerTest {
 
-    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/src/test/java/nablarch/test/core/http/RequestResponseCookieManagerTest.java
+++ b/src/test/java/nablarch/test/core/http/RequestResponseCookieManagerTest.java
@@ -17,18 +17,19 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * {@link RequestResponseCookieManager}のテスト
  */
 public class RequestResponseCookieManagerTest {
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 


### PR DESCRIPTION
- deprecatedなメソッドの警告をサプレス（ExpectedException.none()）
- deprecatedなメソッドを置換（assertThat()）